### PR TITLE
remove "get started" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -419,49 +419,6 @@
       </article>
     </div>
 
-    <div class="flex-center" id="start">
-      <div class="container-wider">
-        <article>
-
-          <div class="flex-left">
-            <h1 class="unit flex-center">Get started</h1>
-          </div>
-
-          <div class="flex-left flex-center flex-middle">
-
-            <div class="unit-1-3">
-              <div>
-                <h2>Java</h2>
-                <p>Follow our <a href="#">Build Java tutorial</a>.</p>
-              </div>
-
-              <div>
-                <h2>C++</h2>
-                <p>Follow our <a href="#">Build C++ tutorial</a>.</p>
-              </div>
-            </div>
-
-            <div class="unit-1-3 hide-on-mobile">
-              <img src="img/get_started.svg">
-            </div>
-
-            <div class="unit-1-3">
-              <div>
-                <h2>Android</h2>
-                <p>Follow our <a href="#">mobile app tutorial</a>.</p>
-              </div>
-
-              <div>
-                <h2>iOS</h2>
-                <p>Follow our <a href="#">mobile app tutorial</a>.</p>
-              </div>
-            </div>
-
-          </div>
-        </article>
-      </div>
-    </div>
-
     <div class="flex-center" id="projects">
       <div class="container-wider">
         <article>


### PR DESCRIPTION
remove "get started" section as a workaround to #10

Let's add that section back once tutorials are actually available and/or when we have some other content for it.