### PR TITLE
Fix most accessibility issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Built with Nix - build software only once</title>
@@ -65,6 +65,11 @@
         margin-top: 15vh;
       }
 
+      #why h3 {
+        font-size: 1.625rem;
+        margin: 0;
+      }
+
       #testimonial {
         background-image: linear-gradient(to right, #3d519a, #43329c);
         margin: 0 0 0 0;
@@ -72,7 +77,7 @@
         box-shadow: 0 0 20px 10px #43329c;
       }
 
-      #testimonial h1 {
+      #testimonial h2 {
         color: #f9ffff;
         text-align: center;
         font-weight: 100;
@@ -116,7 +121,7 @@
         background-position: center;
       }
 
-      article > .flex-left > h1 {
+      section h2 {
         font-size: 3rem;
         color: #43329c;
         font-weight: 100;
@@ -138,6 +143,8 @@
         color: #43329c;
         font-weight: 100;
         text-align: center;
+        font-size: 1.625rem;
+        margin: 1.875rem 0 0;
       }
 
       #projects pre {
@@ -227,7 +234,7 @@
           min-height: 50vh;
         }
 
-        #testimonial h1 {
+        #testimonial h2 {
           font-size: 3rem;
         }
 
@@ -248,11 +255,13 @@
   </head>
   <body>
 
-    <div id="top">
-      <header class="flex-center" id="menu">
+    <header id="top">
+      <div class="flex-center" id="menu">
         <div class="container-wider">
           <div class="flex-left flex-wrap">
-            <div class="unit-1-3 flex-middle flex-center unit-1-on-mobile"><img src="img/nix.svg" alt="Built with Nix logo"></div>
+            <div class="unit-1-3 flex-middle flex-center unit-1-on-mobile">
+              <img alt="Built with Nix logo" role="img" src="img/nix.svg">
+            </div>
             <div class="unit-1-3 hide-on-mobile">&nbsp;</div>
             <div class="unit-1-3 unit-1-on-mobile">
               <nav class="flex-right">
@@ -263,11 +272,11 @@
             </div>
           </div>
         </div>
-      </header>
+      </div>
 
       <div class="flex-center" id="intro">
         <div class="container-wider">
-          <article class="flex-left flex-wrap">
+          <div class="flex-left flex-wrap">
             <div class="unit-1 flex-center">
               <h1>Build software only once</h1>
             </div>
@@ -275,202 +284,204 @@
             <div class="unit-1 flex-center">
               <a href="https://nixos.org/nix/download.html">Get Nix</a>
             </div>
-          </article>
+          </div>
         </div>
       </div>
-    </div>
+    </header>
 
-    <div class="flex-center" id="why">
-      <div class="container-wider">
-        <article>
-          <div class="flex-left">
-            <h1 class="unit flex-center">Why Nix?</h1>
-          </div>
-
-          <div class="feature flex-left flex-wrap">
-            <div class="image unit-1-3 unit-1-on-mobile flex-center flex-middle">
-              <img src="img/works.svg"/>
+    <main>
+      <section class="flex-center" id="why">
+        <div class="container-wider">
+          <div>
+            <div class="flex-left">
+              <h2 class="unit flex-center">Why Nix?</h2>
             </div>
 
-            <div class="content unit">
-              <h2>Works on my machine, works in CI, works in production</h2>
-              <p>Nix controls all dependencies precisely and sandboxes all of the builds. Save debugging time by making it easy to reproduce CI or production errors locally. Never think about cache invalidation again.</p>
-            </div>
-          </div>
-
-          <div class="feature flex-left flex-wrap">
-            <div class="image unit-1-3 unit-1-on-mobile flex-center flex-middle">
-              <img src="img/languages.svg"/>
-            </div>
-            <div class="content unit">
-              <h2>One tool, many languages</h2>
-              <p>With today's polyglot environments, each language has its own way of building and testing. Encourage cross-team development by providing a single way of building everything.</p>
-            </div>
-          </div>
-
-          <div class="feature flex-left flex-wrap">
-            <div class="image unit-1-3 unit-1-on-mobile flex-center flex-middle">
-              <img src="img/zero_to_cloud.svg"/>
-            </div>
-            <div class="content unit">
-              <h2>From zero to cloud</h2>
-              <p>Use the same tool to build one project or even one hundred projects, configure machines and deploy to the cloud. Thanks to the extensible Nix language, it's easy to compose parts together with little overhead.</p>
-            </div>
-          </div>
-
-          <div class="feature flex-left flex-wrap">
-            <div class="image unit-1-3 unit-1-on-mobile flex-center flex-middle">
-              <img src="img/packages.svg"/>
-            </div>
-            <div class="content unit">
-              <h2>Pull from a rich package set</h2>
-              <p>Take advantage of more than 10,000 predefined build expressions, including security updates.</p>
-            </div>
-          </div>
-
-          <div class="feature flex-left flex-wrap">
-            <div class="image unit-1-3 unit-1-on-mobile flex-center flex-middle">
-              <img src="img/compile.svg"/>
-            </div>
-            <div class="content unit-2-3 unit-1-on-mobile">
-              <h2>Never compile the same project twice</h2>
-              <p>Nix allows to easily share build results across machines. If the CI has built the project, developers or servers can download the build results instead of re-building the same thing.</p>
-            </div>
-          </div>
-        </article>
-      </div>
-    </div>
-
-    <div class="flex-vertical flex-center" id="testimonial">
-      <article>
-        <div class="flex-left">
-          <h1 class="unit-1 flex-center">Trusted by industry leaders</h1>
-        </div>
-
-        <div class="flex-left">
-          <div class="carousel-container unit-1">
-            <div class="carousel">
-              <input class="carousel__activator" type="radio" name="carousel" id="F" checked="checked"/>
-              <input class="carousel__activator" type="radio" name="carousel" id="G"/>
-              <input class="carousel__activator" type="radio" name="carousel" id="H"/>
-
-              <div class="carousel__controls">
-                <label class="carousel__control carousel__control--backward" for="H"></label>
-                <label class="carousel__control carousel__control--forward" for="G"></label>
+            <div class="feature flex-left flex-wrap">
+              <div class="image unit-1-3 unit-1-on-mobile flex-center flex-middle">
+                <img alt="" role="img" src="img/works.svg" />
               </div>
 
-              <div class="carousel__controls">
-                <label class="carousel__control carousel__control--backward" for="F"></label>
-                <label class="carousel__control carousel__control--forward" for="H"></label>
+              <div class="content unit">
+                <h3>Works on my machine, works in CI, works in production</h3>
+                <p>Nix controls all dependencies precisely and sandboxes all of the builds. Save debugging time by making it easy to reproduce CI or production errors locally. Never think about cache invalidation again.</p>
               </div>
+            </div>
 
-              <div class="carousel__controls">
-                <label class="carousel__control carousel__control--backward" for="G"></label>
-                <label class="carousel__control carousel__control--forward" for="F"></label>
+            <div class="feature flex-left flex-wrap">
+              <div class="image unit-1-3 unit-1-on-mobile flex-center flex-middle">
+                <img alt="" role="img" src="img/languages.svg"/>
               </div>
+              <div class="content unit">
+                <h3>One tool, many languages</h3>
+                <p>With today's polyglot environments, each language has its own way of building and testing. Encourage cross-team development by providing a single way of building everything.</p>
+              </div>
+            </div>
 
-              <div class="carousel__track">
-                <li class="carousel__slide">
-                  <h3>tweag.io</h3>
-                  <blockquote>
-                    We use Nix for reproducible builds in several of our client projects, including large projects involving multiple teams across several continents.
-                    Interestingly we've also found Nix to be a great way to build RPM artifacts. i.e. using it purely as build system, not nixpkgs.
-                  </blockquote>
-                  <div class="author">&mdash; Mathieu Boespflug</div>
-                </li>
+            <div class="feature flex-left flex-wrap">
+              <div class="image unit-1-3 unit-1-on-mobile flex-center flex-middle">
+                <img alt="" role="img" src="img/zero_to_cloud.svg"/>
+              </div>
+              <div class="content unit">
+                <h3>From zero to cloud</h3>
+                <p>Use the same tool to build one project or even one hundred projects, configure machines and deploy to the cloud. Thanks to the extensible Nix language, it's easy to compose parts together with little overhead.</p>
+              </div>
+            </div>
 
-                <li class="carousel__slide">
-                  <h3>Flying Circus</h3>
-                  <blockquote>
-                    Our second-generation platform is based upon NixOS. We are currently providing a subset of the features and components that are available on our first-generation Gentoo-based platform.
-                  </blockquote>
-                  <div class="author">&mdash; Christian Theune & Christian Zagrodnick</div>
-                </li>
+            <div class="feature flex-left flex-wrap">
+              <div class="image unit-1-3 unit-1-on-mobile flex-center flex-middle">
+                <img alt="" role="img" src="img/packages.svg"/>
+              </div>
+              <div class="content unit">
+                <h3>Pull from a rich package set</h3>
+                <p>Take advantage of more than 10,000 predefined build expressions, including security updates.</p>
+              </div>
+            </div>
 
-                <li class="carousel__slide">
-                  <h3>LumiGuide</h3>
-                  <blockquote>
-                    We use NixOS to power our fleet of image-analysis servers which are detecting available space to park your bicycle in Dutch bicycle parking facilities. We have a cluster of machines running NixOS at a professional hosting provider powering our web-based management system. We use the whole eco-system: nixpkgs, NixOS, nixops and hydra.
-                  </blockquote>
-                  <div class="author">&mdash; Bas van Dijk</div>
-                </li>
+            <div class="feature flex-left flex-wrap">
+              <div class="image unit-1-3 unit-1-on-mobile flex-center flex-middle">
+                <img alt="" role="img" src="img/compile.svg"/>
+              </div>
+              <div class="content unit-2-3 unit-1-on-mobile">
+                <h3>Never compile the same project twice</h3>
+                <p>Nix allows to easily share build results across machines. If the CI has built the project, developers or servers can download the build results instead of re-building the same thing.</p>
               </div>
             </div>
           </div>
         </div>
-      </article>
-    </div>
+      </section>
 
-    <div class="flex-center" id="projects">
-      <div class="container-wider">
-        <article>
+      <section class="flex-vertical flex-center" id="testimonial">
+        <div>
           <div class="flex-left">
-            <h1 class="unit flex-center">Projects built with Nix</h1>
+            <h2 class="unit-1 flex-center">Trusted by industry leaders</h2>
           </div>
 
-          <div class="flex-left flex-wrap">
-            <p class="unit-1">
-              Curated list of projects built with Nix
-            </p>
+          <div class="flex-left">
+            <div class="carousel-container unit-1">
+              <div class="carousel">
+                <input class="carousel__activator" type="radio" name="carousel" id="F" checked="checked"/>
+                <input class="carousel__activator" type="radio" name="carousel" id="G"/>
+                <input class="carousel__activator" type="radio" name="carousel" id="H"/>
 
-            <ul class="unit-1 dashed">
-              <li class="flex-center">
-                <a href="https://github.com/nix-community/todomvc-nix">TodoMVC w/ JavaScript frontend and Haskell backend</a>
-              </li>
-              <li class="flex-center">
-                <a href="https://dapp.tools">dapp.tools</a>
-              </li>
-              <li class="flex-center">
-                <a href="https://github.com/srid/rib#readme">Rib: Haskell static site generator</a>
-              </li>
-              <li class="flex-center">
-                <a href="https://dhall-lang.org/">Dhall configuration language</a>
-              </li>
-              <li class="flex-center">
-                <a href="https://github.com/rpearce/bashcards">bashcards: CLI tool to practice flashcards</a>
-              </li>
-            </ul>
+                <div class="carousel__controls">
+                  <label class="carousel__control carousel__control--backward" for="H"></label>
+                  <label class="carousel__control carousel__control--forward" for="G"></label>
+                </div>
 
-            <div class="unit-1 image">
-              <img src="img/built_with_nix.svg"/>
+                <div class="carousel__controls">
+                  <label class="carousel__control carousel__control--backward" for="F"></label>
+                  <label class="carousel__control carousel__control--forward" for="H"></label>
+                </div>
+
+                <div class="carousel__controls">
+                  <label class="carousel__control carousel__control--backward" for="G"></label>
+                  <label class="carousel__control carousel__control--forward" for="F"></label>
+                </div>
+
+                <ul class="carousel__track" role="list">
+                  <li class="carousel__slide" role="listitem">
+                    <h3>tweag.io</h3>
+                    <blockquote>
+                      We use Nix for reproducible builds in several of our client projects, including large projects involving multiple teams across several continents.
+                      Interestingly we've also found Nix to be a great way to build RPM artifacts. i.e. using it purely as build system, not nixpkgs.
+                    </blockquote>
+                    <div class="author">&mdash; Mathieu Boespflug</div>
+                  </li>
+
+                  <li class="carousel__slide" role="listitem">
+                    <h3>Flying Circus</h3>
+                    <blockquote>
+                      Our second-generation platform is based upon NixOS. We are currently providing a subset of the features and components that are available on our first-generation Gentoo-based platform.
+                    </blockquote>
+                    <div class="author">&mdash; Christian Theune & Christian Zagrodnick</div>
+                  </li>
+
+                  <li class="carousel__slide" role="listitem">
+                    <h3>LumiGuide</h3>
+                    <blockquote>
+                      We use NixOS to power our fleet of image-analysis servers which are detecting available space to park your bicycle in Dutch bicycle parking facilities. We have a cluster of machines running NixOS at a professional hosting provider powering our web-based management system. We use the whole eco-system: nixpkgs, NixOS, nixops and hydra.
+                    </blockquote>
+                    <div class="author">&mdash; Bas van Dijk</div>
+                  </li>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="flex-center" id="projects">
+        <div class="container-wider">
+          <div>
+            <div class="flex-left">
+              <h2 class="unit flex-center">Projects built with Nix</h2>
             </div>
 
-            <p class="unit-1">
-              <strong>Is your project missing from the list?</strong><br/>
-              Share the love by embedding the badge into your project's README:
-            </p>
-
-            <div class="unit-1">
-              <h2 class="unit-1">Markdown</h2>
-              <pre class="unit-1">[![built with nix](https://builtwithnix.org/badge.svg)](https://builtwithnix.org)</pre>
-
-              <h2 class="unit-1">reStructuredText</h2>
-              <pre class="unit-1">.. image:: https://builtwithnix.org/badge.svg :alt: built with nix :target: https://builtwithnix.org</pre>
-
-              <h2 class="unit-1">AsciiDoc</h2>
-              <pre class="unit-1">image:https://builtwithnix.org/badge.svg["built with nix", link="https://builtwithnix.org/"]</pre>
-
-              <p class="unit-1 fork">
-                Fork <a href="https://github.com/nix-community/builtwithnix.org">https://github.com/nix-community/builtwithnix.org</a><br/>
-                and submit a pull-request to list your project.
+            <div class="flex-left flex-wrap">
+              <p class="unit-1">
+                Curated list of projects built with Nix
               </p>
+
+              <ul class="unit-1 dashed">
+                <li class="flex-center">
+                  <a href="https://github.com/nix-community/todomvc-nix">TodoMVC w/ JavaScript frontend and Haskell backend</a>
+                </li>
+                <li class="flex-center">
+                  <a href="https://dapp.tools">dapp.tools</a>
+                </li>
+                <li class="flex-center">
+                  <a href="https://github.com/srid/rib#readme">Rib: Haskell static site generator</a>
+                </li>
+                <li class="flex-center">
+                  <a href="https://dhall-lang.org/">Dhall configuration language</a>
+                </li>
+                <li class="flex-center">
+                  <a href="https://github.com/rpearce/bashcards">bashcards: CLI tool to practice flashcards</a>
+                </li>
+              </ul>
+
+              <div class="unit-1 image">
+                <img alt="Built with Nix badge" src="img/built_with_nix.svg"/>
+              </div>
+
+              <p class="unit-1">
+                <strong>Is your project missing from the list?</strong><br/>
+                Share the love by embedding the badge into your project's README:
+              </p>
+
+              <div class="unit-1">
+                <h2 class="unit-1">Markdown</h2>
+                <pre class="unit-1">[![built with nix](https://builtwithnix.org/badge.svg)](https://builtwithnix.org)</pre>
+
+                <h2 class="unit-1">reStructuredText</h2>
+                <pre class="unit-1">.. image:: https://builtwithnix.org/badge.svg :alt: built with nix :target: https://builtwithnix.org</pre>
+
+                <h2 class="unit-1">AsciiDoc</h2>
+                <pre class="unit-1">image:https://builtwithnix.org/badge.svg["built with nix", link="https://builtwithnix.org/"]</pre>
+
+                <p class="unit-1 fork">
+                  Fork <a href="https://github.com/nix-community/builtwithnix.org">https://github.com/nix-community/builtwithnix.org</a><br/>
+                  and submit a pull-request to list your project.
+                </p>
+              </div>
             </div>
           </div>
-        </article>
-      </div>
-    </div>
+        </div>
+      </section>
 
-    <div class="flex-center hide-on-mobile" id="icons">
-      <div class="container-fluid">
-        <div class="icons">
-          <img src="img/works_simple.svg"/>
-          <img src="img/languages_simple.svg"/>
-          <img src="img/zero_to_cloud_simple.svg"/>
-          <img src="img/packages_simple.svg"/>
-          <img src="img/compile_simple.svg"/>
+      <div class="flex-center hide-on-mobile" id="icons">
+        <div class="container-fluid">
+          <div class="icons">
+            <img alt="" role="img" src="img/works_simple.svg"/>
+            <img alt="" role="img" src="img/languages_simple.svg"/>
+            <img alt="" role="img" src="img/zero_to_cloud_simple.svg"/>
+            <img alt="" role="img" src="img/packages_simple.svg"/>
+            <img alt="" role="img" src="img/compile_simple.svg"/>
+          </div>
         </div>
       </div>
-    </div>
+    </main>
 
     <style>
       .carousel {


### PR DESCRIPTION
Fixes https://github.com/nix-community/builtwithnix.org/issues/18

I wanted to get this out to y'all before I become a father in the next week or so. My wife went to bed early, so here you go!

_Note: I really didn't want to touch the CSS because it seemed a little complex with the two `style` definitions and the reset file, but the result should be pixel-perfect with what's out there right now._

## Tools used
* deque's [axe](https://www.deque.com/axe/) browser plugin
* VoiceOver on Safari (I don't have time right now to do all the others, but I've got a good nose for this at this point)

## Explanations
* SVGs as `<img />` sources get announced as `group`, and in VoiceOver, if the SVG has elements inside it, they all get announced as "image", "image", "image" unless we put `role="img"` on the `<img />`
* We _always_ need an `alt` attribute on `<img />` tags. If it's decorative, specify `alt=""` to tell the screen reader that it's decorative. Read this to learn more: https://www.w3.org/WAI/tutorials/images/decorative/
* I split the `<header>` and `<main>` sections based on what was acting as what. You can check out the [`<header>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header) and [`<main>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main) MDN pages for more info.
* I don't recommend ever having more than 1 `<h1>` on a page unless the sub-contents are truly separate content (articles). This can confuse people as to what the main purpose of the page is when the headings are all laid out. That said, in my opinion, these are sections of the page that are all around the same concept instead of individual articles like blog post articles. This doesn't mean I'm right, but this is my opinion.
* If you add `list-style: none` to `<ul>` or `<ol>` or `<li>`, VoiceOver loses all list semantics. The fix for this is to put a redundant role of `list` on lists and `listitem` on list items.

## Recommendations
* I recommend checking out a concept known as "functional CSS" whereby we make CSS classes for each individual style and then compose them together on the elements that you want to. This makes styling for the web drastically simpler, in my opinion. For example:
    ```css
    .fs2 { font-size: 2rem; }
    .tac { text-align: center; }
    ```
    ```html
    <div class="fs2 tac">Please center me</div>
    ```
* A note about resets and `px`... I wouldn't bother with CSS resets these days. It also seems that this one is using `px` -- when it comes to units on the web, you should pretty much _always_ be using `rem` for anything that should scale with the browser's font size or a user stylesheet that is overriding the root font size. I need to update this on my own website (where's the time?), but I only recommend using `px` if you have a separator of some type that is purely a visual separator between one thing and something else.
* The carousel's `min-height` is `50vw`, but since its content is absolutely positioned, this means it'll never take up more space than that. This can unfortunately result in losing visual access to content, and this gets worse if you increase the font-size, letter-spacing, and word-spacing, resulting in a loss of content that violates [Success Criterion 1.4.12: Text Spacing](https://www.w3.org/WAI/WCAG21/Understanding/text-spacing.html).
  <details><summary>Expand to see screenshot</summary> <img width="516" alt="image" src="https://user-images.githubusercontent.com/592876/93656185-f8961a80-fa17-11ea-8f27-465e999423b3.png"></details>
* Putting text on top of an image, especially one like in the header area, can be pretty difficult for folks to read, especially those with cognitive disabilities. It's generally a good idea to have the text on a solid background, and if that's not feasible, leveraging things like `text-shadow` and `color` to make it "pop" as much as possible to distinguish it clearly from the background and reduce the noise around it.
* It's no big deal, but [`blockquote`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote) has some cool stuff about it that can be leveraged like a `<footer>` and `<cite>`.