### PR TITLE
fix: update nixos.org urls

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,9 +265,8 @@
             <div class="unit-1-3 hide-on-mobile">&nbsp;</div>
             <div class="unit-1-3 unit-1-on-mobile">
               <nav class="flex-right">
-                <div class="unit"><a href="https://nixos.org/nix/about.html">About</a></div>
-                <div class="unit"><a href="https://nixos.org/download.html">Download</a></div>
-                <div class="unit"><a href="https://nixos.org/nix/manual/">Manual</a></div>
+                <div class="unit"><a href="https://nixos.org/download/">Download</a></div>
+                <div class="unit"><a href="https://nixos.org/manual/nix/stable/">Manual</a></div>
               </nav>
             </div>
           </div>
@@ -282,7 +281,7 @@
             </div>
 
             <div class="unit-1 flex-center">
-              <a href="https://nixos.org/nix/download.html">Get Nix</a>
+              <a href="https://nixos.org/download/">Get Nix</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Update URLs that return 404 or redirect. Also remove the "About" link since it now redirects to https://nixos.org/explore/